### PR TITLE
[Feature] 지하철 노선에 따라 정렬 방식 다르게 설정 

### DIFF
--- a/src/main/java/com/sopt/wokat/domain/place/entity/SpaceInfo.java
+++ b/src/main/java/com/sopt/wokat/domain/place/entity/SpaceInfo.java
@@ -119,6 +119,10 @@ public class SpaceInfo extends BaseEntity {
     @Schema(description = "S3 이미지 URL")
     private List<String> imageURLs;
 
+    @Field("station_distance")                      //! [역이름: 역까지 도보거리]
+    @Schema(description = "서울 자치구 별 지하철역~공간 도보거리")
+    private Map<String, Object> walkTime;
+
     public static SpaceInfo createSpaceInfo (PostPlaceRequest placeRequest) {
         SpaceInfo spaceInfo = SpaceInfo.builder()
                 .space(Space.fromValue(placeRequest.getSpaceClass().toString()))

--- a/src/main/java/com/sopt/wokat/domain/place/repository/PlaceRepositoryCustom.java
+++ b/src/main/java/com/sopt/wokat/domain/place/repository/PlaceRepositoryCustom.java
@@ -20,7 +20,7 @@ public interface PlaceRepositoryCustom {
 
     OnePlaceInfoResponse findByIdCustom(String id) throws PlaceNotFoundException ;
     
-    List<FilteringPlaceResponse> findSpaceByProperties(Space space, String area, String station,
-            CoordinateDTO stationCoord, FilteringPlaceRequest filteringPlaceRequest);
+    List<FilteringPlaceResponse> findSpaceByProperties(Space space, String area, String station, 
+            Boolean isMainStation, CoordinateDTO stationCoord, FilteringPlaceRequest filteringPlaceRequest);
 
 }

--- a/src/main/java/com/sopt/wokat/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/sopt/wokat/domain/place/repository/PlaceRepositoryImpl.java
@@ -6,17 +6,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
 import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -78,35 +80,57 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
     public OnePlaceInfoResponse findByIdCustom(String id) throws PlaceNotFoundException {
         SpaceInfo spaceInfo = mongoTemplate.findById(id, SpaceInfo.class);
         if (spaceInfo == null) throw new PlaceNotFoundException();
-        LOGGER.info(spaceInfo);
+
         OnePlaceInfoResponse placeInfoResponse = OnePlaceInfoResponse.createOnePlaceInfoResponse(spaceInfo);
         return placeInfoResponse;
     }
 
     @Override
     public List<FilteringPlaceResponse> findSpaceByProperties(Space space, String area, String station,
-                    CoordinateDTO stationCoord, FilteringPlaceRequest filteringPlaceRequest) {
-        //* DB에서 필터링 결과 가져오기 
-        Pageable pageable = PageRequest.of(filteringPlaceRequest.getPage(), 100, 
-                    Sort.by(Sort.Direction.ASC, "name"));
-        Query query = new Query().with(pageable);
+                Boolean isMainStation, CoordinateDTO stationCoord, FilteringPlaceRequest filteringPlaceRequest) {
+        List<AggregationOperation> pipeline = new ArrayList<>();
 
-        List<Criteria> criteria = new ArrayList<>();
-        
         //! 1) 카페/무료회의룸/무료공간 필터링
-        criteria.add(Criteria.where("space").is(space));
-        //! 2) 지역 필터링
-        criteria.add(Criteria.where("area").is(area));
-        
-        query.addCriteria(new Criteria().andOperator(criteria.toArray(new Criteria[criteria.size()])));
-        List<SpaceInfo> spaceList = mongoTemplate.find(query, SpaceInfo.class); 
+        pipeline.add(Aggregation.match(Criteria.where("space").is(space)));
 
-        //! 거리순 정렬하기 
-        List<SpaceInfo> sortedSpace = sortSpaceByDist(spaceList, station, stationCoord);
+        //! 2) 지역 필터링
+        pipeline.add(Aggregation.match(Criteria.where("area").is(area)));
+
+        //! 3-1) station이 01~09호선에 포함되는 경우 도보거리 바로 가져와서 정렬
+        if (isMainStation) {
+            pipeline.add(Aggregation.project()
+                .and("station_distance."+station).as("walkTimeValue")  //? 도보거리 정렬 
+                .andInclude("_id", "space_name", "space_distance", "space_headCount", "space_hashTag", "space_roadName", "space_images")
+            );
+            pipeline.add(Aggregation.sort(Sort.Direction.ASC, "walkTimeValue"));
+
+        } else {    //! 3-2) 그 외의 노선인 경우 도보거리 api 요청 후 정렬
+            pipeline.add(Aggregation.project()
+                .andInclude("_id", "space_name", "space_distance", "space_headCount", "space_hashTag", "space_roadName", "space_images")
+            );
+            pipeline.add(Aggregation.sort(Sort.Direction.ASC, "space_name"));
+        }
+
+        //! Pagination 설정
+        int page = filteringPlaceRequest.getPage();
+        int size = 100;
+        pipeline.add(Aggregation.skip((long) (page * size)));
+        pipeline.add(Aggregation.limit(size));
+
+
+        TypedAggregation<SpaceInfo> aggregation = Aggregation.newAggregation(SpaceInfo.class, pipeline);
+        AggregationResults<SpaceInfo> results = mongoTemplate.aggregate(aggregation, SpaceInfo.class);
+        List<SpaceInfo> spaceList = results.getMappedResults();
+        
+        //! 1~9 이외의 노선인 경우 따로 API 호출해서 정렬 
+        if (!isMainStation) {
+            List<SpaceInfo> sortedSpace = sortSpaceByDist2(spaceList, station, stationCoord);
+            spaceList = sortedSpace;
+        }
 
         //! DTO 넣기
         List<FilteringPlaceResponse> spaceReturnList = new ArrayList<>();
-        for (SpaceInfo spaceInfo : sortedSpace) {
+        for (SpaceInfo spaceInfo : spaceList) {
             FilteringPlaceResponse placeReturnDTO = new FilteringPlaceResponse();
             placeReturnDTO.setId(spaceInfo.getId());
             placeReturnDTO.setPlace(spaceInfo.getName());
@@ -119,45 +143,23 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
             spaceReturnList.add(placeReturnDTO);
         }
 
+
         return spaceReturnList;
     }
 
-    public List<SpaceInfo> sortSpaceByDist(List<SpaceInfo> spaceList, String station, CoordinateDTO stationCoord) {
-        Collections.sort(spaceList, new Comparator<SpaceInfo>() {
-            @Override
-            public int compare(SpaceInfo space1, SpaceInfo space2) {
-                //! 각 공간의 위경도 가져오기
-                CoordinateDTO coordinate1;
-                CoordinateDTO coordinate2;
-
+    //* Tmap API 활용해 도보거리 측정 
+    public List<SpaceInfo> sortSpaceByDist2(List<SpaceInfo> spaceList, String station, CoordinateDTO stationCoord) {
+    return spaceList.stream()
+            .sorted(Comparator.comparingInt(space -> {
                 try {
-                    coordinate1 = apiLocationToCoord.getCoordByLocation(space1.getLocationRoadName());
-                    coordinate2 = apiLocationToCoord.getCoordByLocation(space2.getLocationRoadName());
-                } catch (URISyntaxException e) {
-                    throw new KakaoAPIRequestException(ErrorCode.LOCATION_TO_COORDS_FAIL);
-                }
-                
-                LOGGER.info("{} {}", coordinate1, coordinate2);
-                //! 공간과 역의 도보거리 
-                int walkTime1;
-                int walkTime2;
-
-                try {
-                    walkTime1 = apiGetWalkingDist.getWalkingDistance(stationCoord, station, coordinate1, space1.getName());
-                    walkTime2 = apiGetWalkingDist.getWalkingDistance(stationCoord, station, coordinate2, space1.getName());
-                    LOGGER.info("{} {}", walkTime1, walkTime2);
+                    CoordinateDTO coordinate = apiLocationToCoord.getCoordByLocation(space.getLocationRoadName());
+                    int walkTime = apiGetWalkingDist.getWalkingDistance(stationCoord, station, coordinate, space.getName());
+                    return walkTime;
                 } catch (URISyntaxException | JSONException e) {
                     throw new TmapAPIRequestException(ErrorCode.GET_WALK_DISTANCE_FAIL);
                 }
-                    
-                int compareResult = Integer.compare(walkTime1, walkTime2);
-                
-                return compareResult;
-                // return 1;
-            }
-        });
-
-        return spaceList;
+            }))
+            .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
## 📌 개요
- Issue 번호 #35 
- [GET] /place/filter/:placeId?page=0&filter=0&station=

## 📝 작업사항
- 검색한 지하철역이 1~9호선에 포함되는지 확인하는 로직 추가
    1. 포함되는 경우  
              -  `검색한 지하철역`이 포함된 서울 자치구에 속하는 모든 공간들 필터링해오기 
              - 이 때, 공간마다 `공간~공간이 속하는 자치구 모든 지하철역` 거리가 DB에 저장되어있음. 
                          ex) 서초구에 속하는 장소 -> { "교대": 2787,  "서초": 2270, "방배": 1876 }
              - 해당 데이터에서 검색한 지하철역을 key값으로 하는 도보거리 value(공간~해당 역의 도보거리)를 오름차순 정렬해 반환 
    2. 포함되지 않는 경우(신분당선, 경의중앙선 등)
              - Tmap의 OpenAPI 사용
              - 검색한 역 ~ `검색한 지하철역`이 포함된 서울 자치구에 속하는 모든 공간들 도보거리 각각 모두 API로 실시간 받아와서 오름차순 정렬 후 반환


## 📣 변경로직
- 모두 OpenAPI 사용해 실시간으로 받아와 오름차순 정렬 -> 자주 검색할 가능성이 높은 1~9호선은 미리 역에서부터의 도보거리 DB에 저장하여 해당 데이터를 기준으로 정렬 