### PR TITLE
[Feature] 영업시간 요일 정렬 

### DIFF
--- a/src/main/java/com/sopt/wokat/domain/place/dto/OnePlaceInfoResponse.java
+++ b/src/main/java/com/sopt/wokat/domain/place/dto/OnePlaceInfoResponse.java
@@ -1,6 +1,8 @@
 package com.sopt.wokat.domain.place.dto;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +90,7 @@ public class OnePlaceInfoResponse {
             if (value instanceof String) {
                 String time = (String) value;
 
-                if (time.equals("휴관")) closedDays.add(day);
+                if (time.equals("휴관") || time.contains("휴관")) closedDays.add(day);
                 else {
                     if (!openDays.containsKey(time)) {
                         openDays.put(time, new ArrayList<>());
@@ -98,6 +100,11 @@ public class OnePlaceInfoResponse {
             }
         }
 
+        //! 요일 정렬
+        List<String> daysOfWeek = Arrays.asList("월", "화", "수", "목", "금", "토", "일");
+        openDays.values().forEach(dayList -> dayList.sort(Comparator.comparingInt(daysOfWeek::indexOf)));
+        closedDays.sort(Comparator.comparingInt(daysOfWeek::indexOf));
+        
         if (!openDays.isEmpty()) result.put("open", openDays);
         if (!closedDays.isEmpty()) result.put("closed", closedDays);
 


### PR DESCRIPTION
## 📌 개요
- Issue 번호  #37 
- [GET] /place/:placeId

## 📝 작업사항
- 묶인 요일별로 정렬이 되어있지 않은 이슈 해결 
     - 더미데이터에 들어가있는 요일 순서대로 map에 들어가기 때문에, 더미데이터 순서대로 결과가 나옴.
       즉, 더미데이터의 요일이 정렬되어있지 않은 경우, 묶인 요일 내에서도 정렬이 되어있지 않음.

       ` "space_time": {
    "일": "10:30 - 20:00",
    "월": "10:00 - 22:00",
    "화": "10:00 - 22:00",
    "수": "10:00 - 22:00",
    "목": "10:00 - 22:00",
    "금": "10:00 - 22:00",
    "토": "10:30 - 20:00"
  }`            
     => 
       <img width="321" alt="박스프레소 강남직영점" src="https://github.com/WOK-AT/WOKAT-SERVER/assets/75441684/23024e79-53cf-4dec-9fd7-32ac10ab4f67">


## 📣 변경로직
- 묶인 요일 내에서 요일순서(월->화->수->목->금->토->일)대로 정렬
- `휴무`라는 말이 들어있는 요일을 영업시간이 아닌 휴무일에 반환되게끔 변경 