### PR TITLE
[Fix] 운영시간끼리 요일 정렬

### DIFF
--- a/src/main/java/com/sopt/wokat/domain/place/dto/OnePlaceInfoResponse.java
+++ b/src/main/java/com/sopt/wokat/domain/place/dto/OnePlaceInfoResponse.java
@@ -101,18 +101,23 @@ public class OnePlaceInfoResponse {
             }
         }
 
-        //! 요일 정렬
+        //? 요일묶음 내 요일 정렬
         List<String> daysOfWeek = Arrays.asList("월", "화", "수", "목", "금", "토", "일");
         openDays.values().forEach(dayList -> dayList.sort(Comparator.comparingInt(daysOfWeek::indexOf)));
         closedDays.sort(Comparator.comparingInt(daysOfWeek::indexOf));
 
-        //! 운영시간 시간 순서대로 정렬 
-        List<String> sortedTimes = new ArrayList<>(openDays.keySet());
-        sortedTimes.sort((time1, time2) -> returnTimeOrder(time1, time2));
+        //? 운영시간 시간끼리 요일 정렬 
+        List<Map.Entry<String, List<String>>> sortedHours = new ArrayList<>(openDays.entrySet());
+
+        sortedHours.sort(Comparator.comparingInt(entry -> {
+            String day = entry.getValue().get(0);
+            String targetDays = "월화수목금토일";
+            return targetDays.indexOf(day);
+        }));
 
         Map<String, List<String>> sortedOpenDays = new LinkedHashMap<>();
-        for (String time : sortedTimes) {
-            sortedOpenDays.put(time, openDays.get(time));
+        for (Map.Entry<String, List<String>> entry : sortedHours) {
+            sortedOpenDays.put(entry.getKey(), entry.getValue());
         }
 
         result.put("open", sortedOpenDays);
@@ -121,6 +126,7 @@ public class OnePlaceInfoResponse {
         return result;
     }
 
+    //! 운영시간 정렬 (오픈시간 빠른 순서 -> 같은 경우, 마감시간 빠른 순서)
     private static int returnTimeOrder(String time1, String time2) {
             String[] startTime1 = time1.split(" - ");
             String[] startTime2 = time2.split(" - ");


### PR DESCRIPTION
## 📌 개요
- Issue 번호 #41 
- [GET] /place/:placeId

## 📝 작업사항
- 운영시간끼리 요일 정렬 

## 📣 변경로직
- 각 운영시간 묶음의 제일 첫번째 요일끼리 비교하여 월->화->수->목->금->토->일 순서로 정렬  
         <img width="276" alt="스크린샷 2023-06-23 오전 4 32 41" src="https://github.com/WOK-AT/WOKAT-SERVER/assets/75441684/90644b5e-f5ae-4595-8af8-79fd9681f8d7">
