### PR TITLE
[Hotfix] 해시태그 없는 경우, 빈 배열 반환

### DIFF
--- a/src/main/java/com/sopt/wokat/domain/place/dto/OnePlaceInfoResponse.java
+++ b/src/main/java/com/sopt/wokat/domain/place/dto/OnePlaceInfoResponse.java
@@ -61,7 +61,12 @@ public class OnePlaceInfoResponse {
     }
 
     public static List<String> hashTags(List<String> hashtags) {
-        List<String> result = hashtags.get(0).equals("") ? new ArrayList<>() : hashtags;
+        List<String> result;
+        if (hashtags.size() != 0) {
+            result = hashtags.get(0).equals("") ? new ArrayList<>() : hashtags;
+        } else {
+            result = new ArrayList<>();
+        }
         return result;
     }
     /*


### PR DESCRIPTION
## 📌 개요
- [GET] /place/:placeId?station=

## 📝 작업사항
- 해시태그 없는 경우, 빈 배열인데 인덱스를 참조하려 하여, 오류 발생
    - .get(0)

## 📣 변경로직
- 빈 배열 아닌 경우에만 인덱스 참조하도록 변경